### PR TITLE
no result error should be stderr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub fn run(args: ArgMatches) {
     }
 
     if torrents.is_empty() {
-        println!("No torrents found matching search query");
+        eprintln!("No torrents found matching search query");
         return;
     }
 


### PR DESCRIPTION
no idea if this is correct, first line of rust code I've written


the reason we want this is so that doing `magnet="$(magnetfinder --no-interactive --show 5 -aq 'asdlkasldkaslkdaslkdasd')"` has `magnet=''` instead of the error message